### PR TITLE
Feat/user events rollup table

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -35,16 +35,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748693115,
-        "narHash": "sha256-StSrWhklmDuXT93yc3GrTlb0cKSS0agTAxMGjLKAsY8=",
+        "lastModified": 1749768417,
+        "narHash": "sha256-itolSjI293jgqbOcFu91bLk0q+6XhXRJ7A8P16ReSTs=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "910796cabe436259a29a72e8d3f5e180fc6dfacc",
+        "rev": "caaedce097b167bc1e15dc1818fd6b2a7657e1fb",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "master",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Lana";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/master";
     flake-utils.url = "github:numtide/flake-utils";
     rust-overlay = {
       url = "github:oxalica/rust-overlay";

--- a/lana/app/migrations/20250619183802_core_user_events_rollup.sql
+++ b/lana/app/migrations/20250619183802_core_user_events_rollup.sql
@@ -1,0 +1,44 @@
+-- Add migration script here
+CREATE TABLE core_user_events_rollup(
+	id         		uuid				NOT NULL,	
+	attributes		jsonb					,
+	recorded_at_latest	timestamp with time zone	NOT NULL,
+	sequence_latest		integer				NOT NULL,
+	event_type_latest	character varying		NOT NULL
+);
+
+ALTER TABLE ONLY public.core_user_events_rollup
+    ADD CONSTRAINT core_user_events_rollup_id_sequence_key UNIQUE (id, sequence_latest);
+
+ALTER TABLE ONLY public.core_user_events_rollup
+    ADD CONSTRAINT core_user_events_rollup_id_fkey FOREIGN KEY (id) REFERENCES public.core_users(id);
+
+CREATE OR REPLACE FUNCTION process_core_user_events_rollup() RETURNS TRIGGER AS $core_user_events_rollup$
+    BEGIN
+        --
+	-- TO DO: add handling for other operation types in source table (DELETE, UPDATE)
+        IF (TG_OP = 'INSERT') THEN
+            INSERT INTO core_user_events_rollup 
+		SELECT
+			new_record.id as id,
+			-- if changed, set key value to value from last user event, and add new keys
+			-- drop fields: type exists in separate col and audit_info is an event not user property
+			COALESCE(rollup.attributes, '{}'::jsonb) || (new_record.event - 'audit_info' - 'type') as attributes,
+			new_record.recorded_at as recorded_at_latest,
+			new_record.sequence as sequence_latest,
+			new_record.event_type as event_type_latest
+		FROM 
+			(SELECT * from core_user_events WHERE id = NEW.id and sequence = NEW.sequence) new_record
+		LEFT JOIN
+			core_user_events_rollup rollup
+		ON
+			rollup.id = new_record.id and rollup.sequence_latest = new_record.sequence - 1;
+	    DELETE FROM core_user_events_rollup where id = NEW.id and sequence_latest = NEW.sequence - 1;
+        END IF;
+        RETURN NULL; 
+    END;
+$core_user_events_rollup$ LANGUAGE plpgsql;
+
+CREATE TRIGGER core_user_events_rollup
+AFTER INSERT ON core_user_events
+    FOR EACH ROW EXECUTE FUNCTION process_core_user_events_rollup();


### PR DESCRIPTION
Notes/Questions:
to strip or record the audit trail info? not a property of a user so stripping it for now
what is the other id (in the event payload)
To do (not implement):
handling deletes/updates to records in the events table -- unlikely(?) but better to add logic to trigger function